### PR TITLE
Discord Intents API, updates links, guilds from state

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -152,10 +152,7 @@ func (bot *Bot) ready(s *discordgo.Session, event *discordgo.Ready) {
 		s.UpdateStatus(0, bot.Prefix+" help")
 		return
 	}
-	// s.UpdateListeningStatus
-	// s.UpdateStreamingStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix), "https://massmover.github.io")
-	s.UpdateStatusComplex(discordgo.UpdateStatusData{Game: &discordgo.Game{Name: "Moved \n test \n tetest", Type: discordgo.GameTypeGame, URL: "https://massmover.github.io", Details: fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix)}, Status: fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix)})
-	// _ = s.UpdateStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix))
+	_ = s.UpdateStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix))
 }
 
 // bumpStatistics adds 1 to the "movs" stats and 'moved' to the "movd"

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -84,7 +84,9 @@ func (bot *Bot) Start() error {
 		log.Println("Error setting up main session: ", err)
 		return err
 	}
-	commander.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuilds | discordgo.IntentsGuildMessages)
+	commander.Identify.Intents = discordgo.MakeIntent(
+		discordgo.IntentsGuilds | discordgo.IntentsGuildMessages |
+			discordgo.IntentsGuildMembers | discordgo.IntentsGuildVoiceStates)
 	commander.AddHandler(bot.guildCreate)
 	commander.AddHandler(bot.guildDelete)
 	commander.AddHandler(bot.messageHandler)
@@ -150,7 +152,10 @@ func (bot *Bot) ready(s *discordgo.Session, event *discordgo.Ready) {
 		s.UpdateStatus(0, bot.Prefix+" help")
 		return
 	}
-	_ = s.UpdateStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix))
+	// s.UpdateListeningStatus
+	// s.UpdateStreamingStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix), "https://massmover.github.io")
+	s.UpdateStatusComplex(discordgo.UpdateStatusData{Game: &discordgo.Game{Name: "Moved \n test \n tetest", Type: discordgo.GameTypeGame, URL: "https://massmover.github.io", Details: fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix)}, Status: fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix)})
+	// _ = s.UpdateStatus(0, fmt.Sprintf("Moved %d players \n ! %s help", stats["usrs"], bot.Prefix))
 }
 
 // bumpStatistics adds 1 to the "movs" stats and 'moved' to the "movd"

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -84,7 +84,7 @@ func (bot *Bot) Start() error {
 		log.Println("Error setting up main session: ", err)
 		return err
 	}
-
+	commander.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuilds | discordgo.IntentsGuildMessages)
 	commander.AddHandler(bot.guildCreate)
 	commander.AddHandler(bot.guildDelete)
 	commander.AddHandler(bot.messageHandler)
@@ -108,6 +108,7 @@ func (bot *Bot) Start() error {
 			log.Println("Error setting powerup session: ", err)
 			continue
 		}
+		powerup.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsGuilds)
 
 		err = powerup.Open()
 		if err != nil {

--- a/bot/move.go
+++ b/bot/move.go
@@ -25,7 +25,7 @@ func (bot *Bot) Move(m *discordgo.MessageCreate, params []string) (string, error
 	workerschann := make(chan []*discordgo.Session, 1)
 	go utils.DetectPowerups(m.GuildID, append(bot.PowerupSessions, bot.MoverSession), workerschann)
 
-	guild, err := bot.MoverSession.Guild(m.GuildID) // retrieving the server (guild) the message was originated from
+	guild, err := bot.MoverSession.State.Guild(m.GuildID) // retrieving the server (guild) the message was originated from
 	if err != nil {
 		log.Println(err)
 		_, _ = bot.MoverSession.ChannelMessageSendEmbed(m.ChannelID, bot.Messages.NotInGuild(bot.GetGuildLocale(m.GuildID), m.Author.Mention()))

--- a/bot/summon.go
+++ b/bot/summon.go
@@ -15,7 +15,7 @@ func (bot *Bot) Summon(m *discordgo.MessageCreate, params []string) (string, err
 	workerschann := make(chan []*discordgo.Session, 1)
 	go utils.DetectPowerups(m.GuildID, append(bot.PowerupSessions, bot.MoverSession), workerschann)
 
-	guild, err := bot.MoverSession.Guild(m.GuildID) // retrieving the server (guild) the message was originated from
+	guild, err := bot.MoverSession.State.Guild(m.GuildID) // retrieving the server (guild) the message was originated from
 	if err != nil {
 		log.Println(err)
 		_, _ = bot.MoverSession.ChannelMessageSendEmbed(m.ChannelID, bot.Messages.NotInGuild(bot.GetGuildLocale(m.GuildID), m.Author.Mention()))

--- a/bot/summon.go
+++ b/bot/summon.go
@@ -19,7 +19,7 @@ func (bot *Bot) Summon(m *discordgo.MessageCreate, params []string) (string, err
 	if err != nil {
 		log.Println(err)
 		_, _ = bot.MoverSession.ChannelMessageSendEmbed(m.ChannelID, bot.Messages.NotInGuild(bot.GetGuildLocale(m.GuildID), m.Author.Mention()))
-		return "", errors.New("notinguild")
+		return "", errors.New("not in guild")
 	}
 
 	destination := utils.GetUserCurrentChannel(bot.MoverSession, m.Author.ID, guild)

--- a/config.model.json
+++ b/config.model.json
@@ -1,6 +1,6 @@
 {
     "MoverBotToken" : "MoverBotToken",
-    "PowerupTokens" : ["servantToken1", "servantToken2"],
-    "BotPrefix" : "-c",
+    "PowerupTokens" : ["powerupToken1", "powerupToken2"],
+    "BotPrefix" : "-",
     "DatabasePath" : "./databases/"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,8 +8,8 @@ var (
 	testConfigPath = "../config.model.json"
 	testConfig     = ConfigurationParameters{
 		MoverBotToken: "MoverBotToken",
-		PowerupTokens: []string{"servantToken1", "servantToken2"},
-		BotPrefix:     "-c",
+		PowerupTokens: []string{"powerupToken1", "powerupToken2"},
+		BotPrefix:     "-",
 		DatabasePath:  "./databases/",
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auyer/massmoverbot
 go 1.14
 
 require (
-	github.com/bwmarrin/discordgo v0.20.3
+	github.com/bwmarrin/discordgo v0.21.1
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auyer/massmoverbot
 go 1.14
 
 require (
-	github.com/bwmarrin/discordgo v0.21.1
+	github.com/bwmarrin/discordgo v0.22.0
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/dgraph-io/ristretto v0.0.2 // indirect
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/bwmarrin/discordgo v0.21.1 h1:UI2PWwzvn5IFuscYcDc6QB/duhs9MUIjQ4HclcIZisc=
-github.com/bwmarrin/discordgo v0.21.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
+github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
+github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/bwmarrin/discordgo v0.20.3 h1:AxjcHGbyBFSC0a3Zx5nDQwbOjU7xai5dXjRnZ0YB7nU=
-github.com/bwmarrin/discordgo v0.20.3/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
+github.com/bwmarrin/discordgo v0.21.1 h1:UI2PWwzvn5IFuscYcDc6QB/duhs9MUIjQ4HclcIZisc=
+github.com/bwmarrin/discordgo v0.21.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/mover/move.go
+++ b/mover/move.go
@@ -130,7 +130,7 @@ Inputs:
 	retry int: the amount of retrys this function will allows
 */
 func MoveAndRetry(s *discordgo.Session, guildID, userID, dest string, retry int) error {
-	err := s.GuildMemberMove(guildID, userID, dest)
+	err := s.GuildMemberMove(guildID, userID, &dest)
 	if err != nil {
 		time.Sleep(time.Millisecond * 20)
 		if retry >= 0 {

--- a/public/messages.yaml
+++ b/public/messages.yaml
@@ -3,19 +3,19 @@ LANG:
   WelcomeAndLang: |
     :flag_us: [EN] Hi ! Thank you for adding this bot.
         Set the language used by the bot in guild's by typing \'%s lang\' and chosing one of the options.
-        Visit the website and add more moving power! http://massmover.github.io
+        Visit the website and add more moving power! https://massmover.github.io 
 
     :flag_br: [PT/BR] Olá ! Obrigado por adicionar este bot.
         Configure a linguagem em sua guild digitando \'%s lang\' e escolhendo uma das opçoes.
-        Visite o site e adicione mais níveis de poder! http://massmover.github.io
+        Visite o site e adicione mais níveis de poder! https://massmover.github.io 
 
     :flag_es: [ES] Hola ! Gracias por añadir este bot.
         Configure el idioma de preferencia escribiendo \'%s lang\' y escogiendo una de las opciones.
-        Visite la página y añada más poder de movimiento! http://massmover.github.io 
+        Visite la página y añada más poder de movimiento! https://massmover.github.io  
 
     :flag_fr: [FR] Salut ! Merci d'avoir ajouté ce bot.
         Choisis le language de ta guilde en utilisant la commande \'%s lang\' et en choisissant une des options.
-        Visite le site afin de déplacer, toujours plus ! http://massmover.github.io
+        Visite le site afin de déplacer, toujours plus ! https://massmover.github.io 
   LangSetupMessage: |
     1 - :flag_us: [EN] Type \'%s lang\' followed by \'EN\' or \'1\' to select the English language
 


### PR DESCRIPTION
This PR includes:
- the usage of the Discord's new Intents API
- Updates links in messages to use https
- retrieves guild list from state
- removes "servant" name from sample configuration file